### PR TITLE
Expose gallery message types

### DIFF
--- a/src/InfiniteGallery.elm
+++ b/src/InfiniteGallery.elm
@@ -3,7 +3,7 @@ module InfiniteGallery exposing
     , init, update, view
     , previous, next, goTo, setIndex
     , getCurrentIndex
-    , Gallery, Msg
+    , Gallery, Msg(..)
     )
 
 {-|
@@ -195,15 +195,10 @@ update msg ((Gallery size config currentSlide dragState slides transitionSpeed) 
 
                 Dragging (PosX startX) (PosX currentX) ->
                     if (startX - currentX) > config.swipeOffset then
-                        update Next gallery
-
-                    else if abs (startX - currentX) > config.swipeOffset then
-                        update Previous gallery
+                        ( gallery, Task.perform (always Next) (Task.succeed ()) )
 
                     else
-                        ( Gallery size config currentSlide NotDragging slides transitionSpeed
-                        , Cmd.none
-                        )
+                        ( gallery, Task.perform (always Previous) (Task.succeed ()) )
 
         Next ->
             ( Gallery size config (currentSlide + 1) NotDragging slides transitionSpeed

--- a/src/InfiniteGallery.elm
+++ b/src/InfiniteGallery.elm
@@ -197,8 +197,13 @@ update msg ((Gallery size config currentSlide dragState slides transitionSpeed) 
                     if (startX - currentX) > config.swipeOffset then
                         ( gallery, Task.perform (always Next) (Task.succeed ()) )
 
-                    else
+                    else if abs (startX - currentX) > config.swipeOffset then
                         ( gallery, Task.perform (always Previous) (Task.succeed ()) )
+
+                    else
+                        ( Gallery size config currentSlide NotDragging slides transitionSpeed
+                        , Cmd.none
+                        )
 
         Next ->
             ( Gallery size config (currentSlide + 1) NotDragging slides transitionSpeed


### PR DESCRIPTION
This gives other modules access to InfiniteGallery's message types like
Previous and Next.

Also includes a change to allow capturing the Previous and Next
messages. Previously DragEnd was calling update recursively, which made
it impossible to capture the Previous and Next messages from another
module. Instead now it triggers Previous and Next as new commands.

Closes #3