### PR TITLE
Expose TransitionSpeed type

### DIFF
--- a/src/InfiniteGallery.elm
+++ b/src/InfiniteGallery.elm
@@ -4,6 +4,7 @@ module InfiniteGallery exposing
     , previous, next, goTo, setIndex
     , getCurrentIndex
     , Gallery, Msg(..)
+    , TransitionSpeed(..)
     )
 
 {-|


### PR DESCRIPTION
This is required to use custom configuration, because the Config type includes a TransitionSpeed type.

Closes #6 