### PR TITLE
Set the initial slide

### DIFF
--- a/src/InfiniteGallery.elm
+++ b/src/InfiniteGallery.elm
@@ -60,6 +60,7 @@ type alias Config =
     , transitionSpeedWhenAdvancing : TransitionSpeed
     , enableDrag : Bool
     , swipeOffset : Int
+    , initialSlide : Int
     }
 
 
@@ -72,6 +73,7 @@ defaultConfig =
     , transitionSpeedWhenAdvancing = TransitionSpeed 300
     , enableDrag = True
     , swipeOffset = 150
+    , initialSlide = 0
     }
 
 
@@ -140,7 +142,7 @@ init size config slides =
     Gallery
         size
         config
-        0
+        config.initialSlide
         NotDragging
         (List.indexedMap Tuple.pair slides)
         config.transitionSpeedWhenAdvancing


### PR DESCRIPTION
Allow opening at a specific slide by setting `initialSlide` in the configuration.

This is a breaking change, however it wasn't possible to use custom configuration until #7 was merged a couple of days ago, so it's unlikely to impact too many people.

Closes #8 